### PR TITLE
OpenDJ 3.0 install working with GenerateSelfSigned certs and hard coded URL for nightly

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -3,7 +3,7 @@
 # If you use released binaries you will need to provide the downloaded zip files in
 #  the frstack/staging/ directory, and 
 # Edit vars/released.yml with the version info
-#release: nightly
+release: nightly
 #release: staged
 #release: released
 #release: "maven-released"

--- a/ansible/roles/opendj/defaults/main.yml
+++ b/ansible/roles/opendj/defaults/main.yml
@@ -11,8 +11,8 @@ fr_user: root
 jenkins_url: "https://builds.forgerock.org/view/OpenDJ/job/OpenDJ%20-%20trunk%20-%20nightly/lastSuccessfulBuild/artifact/build/package"
 opendj_major: "OpenDJ-2.7.0"
 opendj_zip: "{{opendj_major}}-{{ansible_date_time.year}}{{ansible_date_time.month}}{{ansible_date_time.day}}.zip"
-opendj_download_url: "{{jenkins_url}}/{{opendj_zip}}"
-
+#opendj_download_url: "{{jenkins_url}}/{{opendj_zip}}"
+opendj_download_url: "http://download.forgerock.org/downloads/opendj/nightly/20150608_1104/OpenDJ-3.0.0-20150608.zip"
 # Directory Manager password
 opendj_password: password
 # BaseDN

--- a/ansible/roles/opendj/tasks/main.yml
+++ b/ansible/roles/opendj/tasks/main.yml
@@ -17,7 +17,7 @@
   template: src=opendj.properties dest=/tmp/opendj.properties 
   
 - name: setup opendj
-  command: creates={{install_root}}/opendj/config {{install_root}}/opendj/setup --cli --propertiesFilePath /tmp/opendj.properties --acceptLicense --no-prompt 
+  command: creates={{install_root}}/opendj/config {{install_root}}/opendj/setup --cli --propertiesFilePath /tmp/opendj.properties --acceptLicense --generateSelfSignedCertificate  --no-prompt 
 
 - name: Create rc script
   command: "{{install_root}}/opendj/bin/create-rc-script -f /etc/init.d/{{opendj_service_name}} -u root"

--- a/ansible/vars/custom.yml
+++ b/ansible/vars/custom.yml
@@ -19,7 +19,8 @@ datestamp: "{{ansible_date_time.year}}{{ansible_date_time.month}}{{ansible_date_
 opendj_datestamp: "{{datestamp}}"
 opendj_major: "OpenDJ-2.6.2"
 opendj_zip: "{{opendj_major}}.zip"
-opendj_download_url: "{{fr_downloads}}/opendj/nightly/{{opendj_datestamp}}_0130/{{opendj_zip}}"
+#opendj_download_url: "{{fr_downloads}}/opendj/nightly/{{opendj_datestamp}}_0130/{{opendj_zip}}"
+opendj_download_url: "http://download.forgerock.org/downloads/opendj/nightly/20150608_1104/OpenDJ-3.0.0-20150608.zip"
 
 # OpenAM builds
 openam_version: "13.0.0-SNAPSHOT"

--- a/ansible/vars/nightly.yml
+++ b/ansible/vars/nightly.yml
@@ -17,8 +17,8 @@ datestamp: "{{ansible_date_time.year}}{{ansible_date_time.month}}{{ansible_date_
 opendj_datestamp: "{{datestamp}}"
 opendj_major: "OpenDJ-2.7.0" 
 opendj_zip: "{{opendj_major}}-{{opendj_datestamp}}.zip"
-opendj_download_url: "{{fr_downloads}}/opendj/nightly/{{opendj_datestamp}}_0130/{{opendj_zip}}"
-
+#opendj_download_url: "{{fr_downloads}}/opendj/nightly/{{opendj_datestamp}}_0130/{{opendj_zip}}"
+opendj_download_url: "http://download.forgerock.org/downloads/opendj/nightly/20150608_1104/OpenDJ-3.0.0-20150608.zip"
 # OpenAM builds
 openam_version: "13.0.0-SNAPSHOT"
 openam_zip: "OpenAM-{{openam_version}}_nightly_{{datestamp}}.zip"


### PR DESCRIPTION
Check out the hard coded URLS these need to be switched out later but I noticed your commits about Nightly Urls not being as predictable as you like. Also the GenerateSelfSignedCerts tag in the configure OpenDJ shell script.

Its still having some issues post install. Not sure if its a step closer or a step backward 