### PR TITLE
Fix "become : command not found" error 

### DIFF
--- a/ansible/frstack.yml
+++ b/ansible/frstack.yml
@@ -18,7 +18,7 @@
   gather_facts: false
   tasks:
     - name: install packages for ansible support
-      raw: become dnf -y -e0 -d0 install python python-dnf
+      raw: sudo dnf -y -e0 -d0 install python python-dnf
 
 # These plays are common to all hosts in the stack. This installs basic packages, java, etc.
 # Put roles here that need to be run on every host in stack


### PR DESCRIPTION
Fix for the following error while running the frstack.yml playbook on Fedora 23 / Ansible 2.0

```
pistache@KernelControl:~/ForgeRock/frstack-master/vagrant$ ./frstack 
ansible-playbook --user=vagrant --private-key /home/pistache/ForgeRock/frstack-master/vagrant/.vagrant/machines/oisserver/virtualbox/private_key -i /home/pistache/ForgeRock/frstack-master/vagrant/.vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory frstack.yml

PLAY ***************************************************************************

TASK [install packages for ansible support] ************************************
fatal: [oisserver]: FAILED! => {"changed": false, "failed": true, "rc": 127, "stderr": "", "stdout": "bash: become : command not found\r\n", "stdout_lines": ["bash: become : command not found"]}

PLAY RECAP *********************************************************************
oisserver                  : ok=0    changed=0    unreachable=0    failed=1
```