### PR TITLE
FIX for ssoadm and agent-apache tags

### DIFF
--- a/ansible/frstack.yml
+++ b/ansible/frstack.yml
@@ -53,8 +53,7 @@
    - { role: opendj, tags: ["opendj"]}
    - { role: openidm, tags: ["openidm"]}
    - { role: openam,  tomcat_openam_dir: "{{tomcat_parent}}/openam", tags: ["openam"]}
-# Currently failing on new nightly builds. TODO: find out why
-#   - { role: ssoadm, tags: ["ssoadm"]}
+   - { role: ssoadm, tags: ["ssoadm"]}
    - { role: openig,  tags: ["openig"]}
    - { role: agent-apache, tags: ["agent", "apache", "agent-apache", "test"]}
 # Note that tomcat-agent install is currently not working.

--- a/ansible/roles/agent-apache/tasks/main.yml
+++ b/ansible/roles/agent-apache/tasks/main.yml
@@ -9,19 +9,18 @@
 - name: create password file
   copy: src=agentpw dest="{{ webagents_home }}/agentpw"
 
-  
 - name: Stop apache
   service: name=httpd state=stopped
   
-- name: Copy agent response template 
-  template: src=agentresponse-custom.txt dest="{{ webagents_home }}/agentresponse-custom.txt" 
+- name: Copy agent config 
+  copy: src=agent-config dest="{{ webagents_home }}/agent-config" 
 
-- name: Run agentadmin 
-  shell: "{{ webagents_home }}/apache24_agent/bin/agentadmin --acceptLicense --custom-install --useResponse {{ webagents_home }}/agentresponse-custom.txt"
+- name: Create agent config in openam using ssoadm
+  shell: "{{ install_root }}/ssoadmin/openam/bin/ssoadm create-agent --realm / --agentname apache1080  --agenttype WebAgent  --adminid amadmin --password-file {{ home_dir }}/etc/amadmin_pw --datafile {{ webagents_home }}/agent-config"
   
-- name: Change ownership of agent files 
-  file: path="{{ webagents_home }}" owner=fr group=apache recurse=yes state=directory
-  
+- name: Run agentadmin
+  shell: "{{ webagents_home }}/apache24_agent/bin/agentadmin --s /etc/httpd/conf/httpd.conf https://{{ openam_fqdn }}:443/openam http://{{ openam_fqdn }}:1080 / apache1080 {{ webagents_home }}/agentpw --changeOwner --acceptLicence"
+
 - name: start apache
   service: name=httpd state=started
-  
+


### PR DESCRIPTION
Hi,

Here are the changes I made :
- ssoadm tag uncommented ; successful install
- agent-apache tag fixed by calling the correct _agentadmin_ syntax. Since _--custom-install_ option disappeared, I use ssoadm to add the web policy agent configuration to openam.

So, at the end of the install, http://openam.example.com is protected by OpenAM but unauthorized even for logged user (you still have to configure a policy or enable sso only mode in the agent configuration).

Tests made with ansible 2.0 / Fedora 23 and last stable release of ForgeRock stack.