### PR TITLE
Fix for tomcat-agent

### DIFF
--- a/ansible/roles/agent-tomcat/files/agent-config
+++ b/ansible/roles/agent-tomcat/files/agent-config
@@ -1,3 +1,6 @@
+com.iplanet.am.server.host=openam.example.com
+com.iplanet.am.server.port=443
+com.iplanet.am.server.protocol=https
 com.sun.identity.agents.config.cdsso.enable=false
 com.sun.identity.agents.config.get.client.host.name=false
 com.sun.identity.agents.config.profile.attribute.fetch.mode=NONE

--- a/ansible/roles/agent-tomcat/tasks/main.yml
+++ b/ansible/roles/agent-tomcat/tasks/main.yml
@@ -12,6 +12,9 @@
   
 - name: create password file
   copy: src=agentpw dest={{agent_instance_dir}}
+
+- name: create agent config file
+  copy: src=agent-config dest={{agent_instance_dir}}
   
 #- name: Copy license agreement so we don't get prompted
 #  copy: src=license.log dest={{agent_instance_dir}}/data
@@ -23,9 +26,15 @@
 - name: Stop tomcat 
   service: name="{{ tomcat_instance }}" state=stopped
 
+- name: Create agent config in openam using ssoadm
+  shell: "{{ install_root }}/ssoadmin/openam/bin/ssoadm create-agent --realm / --agentname {{ tomcat_instance }}  --agenttype J2EEAgent  --adminid amadmin --password-file {{ home_dir }}/etc/amadmin_pw --datafile {{ agent_instance_dir }}/agent-config"
+
 - name: Run agentadmin 
-  command: "{{agent_instance_dir}}/bin/agentadmin --acceptLicense --custom-install --useResponse {{agent_instance_dir}}/{{tomcat_instance}}-response.txt"
-  
+  command: "runuser -l {{fr_user}} -c '{{agent_instance_dir}}/bin/agentadmin --acceptLicense --custom-install --useResponse {{agent_instance_dir}}/{{tomcat_instance}}-response.txt'"
+
+- name: Create sample application
+  command: "runuser -l {{fr_user}} -c 'cp {{agent_instance_dir}}/sampleapp/dist/agentsample.war {{ tomcat_instance_dir }}/webapps'"
+
 - name: Start tomcat
   service: name={{ tomcat_instance }} state=started
   

--- a/ansible/roles/agent-tomcat/templates/agentresponse.txt
+++ b/ansible/roles/agent-tomcat/templates/agentresponse.txt
@@ -1,14 +1,14 @@
 # Agent Response File
-CONFIG_DIR="{{ tomcat_instance_dir }}/conf"
-CATALINA_HOME="{{tomcat_instance_dir }}"
+CONFIG_DIR={{ tomcat_instance_dir }}/conf
+CATALINA_HOME={{tomcat_instance_dir }}
 # doesnt work - due to bug. http://bugster.forgerock.org/jira/browse/OPENAM-3209
 # Note: installing in global.xml is not recommended. See http://bugster.forgerock.org/jira/browse/OPENAM-3088
-#INSTALL_GLOBAL_WEB_XML= true
-AM_SERVER_URL="http://{{ openam_fqdn }}:{{openam_server_port}}/openam"
-AGENT_URL="http://{{ openam_fqdn }}:{{tomcat_port}}/agentapp"
-AGENT_ENCRYPT_KEY="z7dZ+dcylZVJBtACNr7irL3PSoLbU/+r"
-AGENT_PROFILE_NAME="{{ tomcat_instance }}"
-AGENT_PASSWORD_FILE="{{agent_instance_dir}}/agentpw"
+INSTALL_GLOBAL_WEB_XML=false
+AM_SERVER_URL=https://{{ openam_fqdn }}:443/openam
+AGENT_URL=http://{{ openam_fqdn }}:{{tomcat_port}}/agentapp
+AGENT_ENCRYPT_KEY=z7dZ+dcylZVJBtACNr7irL3PSoLbU/+r
+AGENT_PROFILE_NAME={{ tomcat_instance }}
+AGENT_PASSWORD_FILE={{agent_instance_dir}}/agentpw
 CREATE_AGENT_PROFILE_NAME= true
 AGENT_ADMINISTRATOR_NAME= amadmin
 AGENT_ADMINISTRATOR_PASSWORD_FILE= {{home_dir}}/etc/amadmin_pw


### PR DESCRIPTION
Hi,

As I promised, here is the fix for the tomcat agent install. I also deployed the agent sample war in http://openam.example.com:3080/agentsample. It is protected, but you will still have to add a policy in OpenAM to grant access to authenticated users.