### PR TITLE
Python requests library wants String or byte headers

### DIFF
--- a/ansible/library/ssoconfigure
+++ b/ansible/library/ssoconfigure
@@ -391,7 +391,7 @@ def main():
         module.fail_json(msg='Configuration failed, unable to start thread')
 
     headers = {"Content-type": "application/x-www-form-urlencoded",
-               "Content-Length": len(body),
+               "Content-Length": str(len(body)),
                'cache-control': 'no-cache'}
     response = requests.post(openssourl, data=body, headers=headers, stream=True)
     response.close()


### PR DESCRIPTION
Hey, I was using frstack to set up the ForgeRock Open Identity Stack, and I ran into an issue with the ssoconfigure module. The Python [requests](https://pypi.python.org/pypi/requests/) library as of 2.11.0 expects String header values.

Here's the fix if you would like it.

Using Ansible 2.0.2.0